### PR TITLE
Update runtime.txt

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.2
+python-3.8.7


### PR DESCRIPTION
python 3.8.2 is not supported by heroku.
https://devcenter.heroku.com/articles/python-support#supported-runtimes